### PR TITLE
Feat: 이미지 생성 API 구현

### DIFF
--- a/src/main/java/elice/aishortform/controller/ImageApiDocs.java
+++ b/src/main/java/elice/aishortform/controller/ImageApiDocs.java
@@ -1,0 +1,21 @@
+package elice.aishortform.controller;
+
+import elice.aishortform.dto.ImageGenerationRequestDto;
+import elice.aishortform.dto.ImageGenerationResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface ImageApiDocs {
+
+    @Operation(
+            summary = "문단 전체 이미지 생성",
+            description = "주어진 summary_id를 기반으로 문단별 이미지를 생성합니다. " +
+                    "- 요청 본문: summaryId (Long) " +
+                    "- 응답: 생성된 이미지 목록과 개수 " +
+                    "- 예외 처리: summaryId가 존재하지 않으면 IllegalArgumentException 발생"
+    )
+    @PostMapping("/generate-all")
+    ResponseEntity<ImageGenerationResponseDto> generateImages(@RequestBody ImageGenerationRequestDto request);
+}

--- a/src/main/java/elice/aishortform/controller/ImageGenerationController.java
+++ b/src/main/java/elice/aishortform/controller/ImageGenerationController.java
@@ -1,0 +1,27 @@
+package elice.aishortform.controller;
+
+import elice.aishortform.dto.ImageGenerationRequestDto;
+import elice.aishortform.dto.ImageGenerationResponseDto;
+import elice.aishortform.dto.ImageGenerationResponseDto.ImageDto;
+import elice.aishortform.service.ImageGenerationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/images")
+@RequiredArgsConstructor
+public class ImageGenerationController {
+
+    private final ImageGenerationService imageGenerationService;
+
+    @PostMapping("/generate-all")
+    public ResponseEntity<ImageGenerationResponseDto> generateImages(@RequestBody ImageGenerationRequestDto request) {
+        List<ImageDto> images = imageGenerationService.generateImages(request.summaryId());
+        return ResponseEntity.ok(new ImageGenerationResponseDto(images, images.size()));
+    }
+}

--- a/src/main/java/elice/aishortform/controller/ImageGenerationController.java
+++ b/src/main/java/elice/aishortform/controller/ImageGenerationController.java
@@ -4,22 +4,23 @@ import elice.aishortform.dto.ImageGenerationRequestDto;
 import elice.aishortform.dto.ImageGenerationResponseDto;
 import elice.aishortform.dto.ImageGenerationResponseDto.ImageDto;
 import elice.aishortform.service.ImageGenerationService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+
+@Tag(name = "Image API", description = "이미지 생성 및 조회 API")
 @RestController
 @RequestMapping("/images")
 @RequiredArgsConstructor
-public class ImageGenerationController {
+public class ImageGenerationController implements ImageApiDocs {
 
     private final ImageGenerationService imageGenerationService;
 
-    @PostMapping("/generate-all")
     public ResponseEntity<ImageGenerationResponseDto> generateImages(@RequestBody ImageGenerationRequestDto request) {
         List<ImageDto> images = imageGenerationService.generateImages(request.summaryId());
         return ResponseEntity.ok(new ImageGenerationResponseDto(images, images.size()));

--- a/src/main/java/elice/aishortform/dto/ImageGenerationRequestDto.java
+++ b/src/main/java/elice/aishortform/dto/ImageGenerationRequestDto.java
@@ -1,0 +1,7 @@
+package elice.aishortform.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ImageGenerationRequestDto(
+        @JsonProperty("summary_id") Long summaryId) {
+}

--- a/src/main/java/elice/aishortform/dto/ImageGenerationResponseDto.java
+++ b/src/main/java/elice/aishortform/dto/ImageGenerationResponseDto.java
@@ -1,0 +1,25 @@
+package elice.aishortform.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageGenerationResponseDto {
+    private List<ImageDto> images;
+
+    @JsonProperty("total_images")
+    private int totalImages;
+
+    @Getter
+    @AllArgsConstructor
+    public static class ImageDto {
+        @JsonProperty("image_id")
+        private String imageId;
+
+        @JsonProperty("image_url")
+        private String imageUrl;
+    }
+}

--- a/src/main/java/elice/aishortform/entity/ImageEntity.java
+++ b/src/main/java/elice/aishortform/entity/ImageEntity.java
@@ -1,0 +1,26 @@
+package elice.aishortform.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "image")
+public class ImageEntity {
+
+    @Id
+    @Column(name = "image_id", nullable = false, unique = true)
+    private String imageId;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+}

--- a/src/main/java/elice/aishortform/global/config/WebConfig.java
+++ b/src/main/java/elice/aishortform/global/config/WebConfig.java
@@ -1,0 +1,26 @@
+package elice.aishortform.global.config;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        exposeDirectory("uploads", registry);
+    }
+
+    private void exposeDirectory(String dirName, ResourceHandlerRegistry registry) {
+        Path uploadDir = Paths.get(dirName).toAbsolutePath().normalize();
+        String uploadPath = uploadDir.toUri().toString();
+
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(uploadPath);
+    }
+}

--- a/src/main/java/elice/aishortform/repository/ImageRepository.java
+++ b/src/main/java/elice/aishortform/repository/ImageRepository.java
@@ -1,0 +1,9 @@
+package elice.aishortform.repository;
+
+import elice.aishortform.entity.ImageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRepository extends JpaRepository<ImageEntity, String> {
+}

--- a/src/main/java/elice/aishortform/service/ImageGenerationService.java
+++ b/src/main/java/elice/aishortform/service/ImageGenerationService.java
@@ -1,0 +1,149 @@
+package elice.aishortform.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import elice.aishortform.dto.ImageGenerationResponseDto.ImageDto;
+import elice.aishortform.entity.ImageEntity;
+import elice.aishortform.entity.Summary;
+import elice.aishortform.global.config.ApiConfig;
+import elice.aishortform.repository.ImageRepository;
+import elice.aishortform.repository.SummaryRepository;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageGenerationService {
+
+    private final SummaryRepository summaryRepository;
+    private final ImageRepository imageRepository;
+    private final ObjectMapper objectMapper;
+
+    private final OkHttpClient client = new OkHttpClient().newBuilder()
+            .retryOnConnectionFailure(true)
+            .build();
+
+    private static final String API_URL = "https://api-cloud-function.elice.io/0133c2f7-9f3f-44b6-a3d6-c24ba8ef4510/generate";
+    private final ApiConfig apiConfig;
+
+    private static final String UPLOAD_DIR = "uploads/";
+
+    public List<ImageDto> generateImages(Long summaryId) {
+        // summary_id에 해당하는 문단들 가져오기
+        Summary summary = summaryRepository.findBySummaryId(summaryId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 summary_id가 존재하지 않습니다: " + summaryId));
+        List<String> paragraphs = summary.getParagraphs();
+
+        // 각 문단에 대해 이미지 생성 API 호출
+        List<ImageDto> images = new ArrayList<>();
+        for (String paragraph : paragraphs) {
+            String imageId = generateUniqueImageId();
+            String base64Image = fetchImages(paragraph);
+
+            // base64 디코딩 -> 파일 저장
+            if (base64Image != null) {
+                String imageUrl = saveImage(base64Image, imageId);
+
+                imageRepository.save(new ImageEntity(imageId, imageUrl));
+
+                images.add(new ImageDto(imageId, imageUrl));
+            }
+        }
+
+        log.info("✅ 이미지 생성 완료 (총 {}개)",images.size());
+
+
+        return images;
+    }
+
+    private String fetchImages(String prompt) {
+        log.info("📌 이미지 생성 요청 ({})",prompt);
+
+        try {
+            Map<String, Object> requestData = createImageRequestData(prompt);
+
+            String responseBody = sendRequest(requestData);
+
+            return extractImage(responseBody);
+        } catch (IOException e) {
+            log.error("❌ 이미지 생성 API 요청 실패",e);
+            return null;
+        }
+    }
+
+    private Map<String, Object> createImageRequestData(String prompt) {
+        return Map.of(
+                "prompt", prompt,
+                "style", "polaroid"
+        );
+    }
+
+    private String sendRequest(Map<String, Object> requestData) throws IOException {
+        String jsonRequestBody = objectMapper.writeValueAsString(requestData);
+        okhttp3.RequestBody body = okhttp3.RequestBody.create(jsonRequestBody, MediaType.parse("application/json"));
+
+        Request request = new Request.Builder()
+                .url(API_URL)
+                .post(body)
+                .addHeader("Accept","application/json")
+                .addHeader("Content-Type","application/json")
+                .addHeader("Authorization",apiConfig.getKey())
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                log.error("❌ API 요청 실패");
+                throw new IOException("API 요청 실패: " + response.code());
+            }
+            assert response.body() != null;
+            return response.body().string();
+        }
+    }
+
+    private String extractImage(String responseBody) throws JsonProcessingException {
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        return jsonNode.path("predictions").asText();
+    }
+
+    private String saveImage(String base64Image, String imageId) {
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(base64Image);
+            File uploadDir = new File(UPLOAD_DIR);
+
+            if (!uploadDir.exists()) {
+                uploadDir.mkdirs();
+            }
+
+            String filePath = UPLOAD_DIR + imageId + ".png";
+            try (FileOutputStream fos = new FileOutputStream(filePath)) {
+                fos.write(decodedBytes);
+            }
+
+            log.info("✅ 이미지 저장 완료 (filePath={})",filePath);
+            return "http://localhost:8080/uploads/" + imageId + ".png";
+        } catch (Exception e) {
+            log.error("❌ 이미지 저장 실패");
+            return null;
+        }
+    }
+
+    private String generateUniqueImageId() {
+        return "img_" + UUID.randomUUID().toString().substring(0,8);
+    }
+
+}


### PR DESCRIPTION
## 📌 작업 내용
- 문단을 기반으로 이미지 생성 API 호출
- 문단별 생성된 이미지 ID를 Summary 엔티티의 paragraphImageMap에 저장
- 이미지 저장 경로 제공을 위한 WebConfig 설정

## 🚀 구현한 API
- POST /images/generate-all 

##  DB 구조
<img width="460" alt="image" src="https://github.com/user-attachments/assets/b5caa4d6-ed6f-4e2d-8947-44eadb0f8b98" />
