### PR TITLE
Refactor: VideoService의 예외를 다시 던지는 방식으로 수정

### DIFF
--- a/src/main/java/elice/aishortform/video/application/VideoService.java
+++ b/src/main/java/elice/aishortform/video/application/VideoService.java
@@ -1,6 +1,7 @@
 package elice.aishortform.video.application;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
@@ -29,8 +30,6 @@ public class VideoService {
 		return CompletableFuture.supplyAsync(() -> {
 			try {
 				// 1. 새로운 비디오 객체 생성 후 저장
-				Video video = new Video(summaryId);
-				videoRepository.save(video);
 				log.info("🎬 비디오 생성 요청 시작 - Summary ID: {}", summaryId);
 
 				// 2. FastAPI 서버에 비디오 생성 요청
@@ -46,7 +45,8 @@ public class VideoService {
 					throw new VideoProcessingException("FastAPI 서버로부터 유효한 응답을 받지 못했습니다.");
 				}
 
-				// 4. 비디오 객체 업데이트 및 저장
+				// 4. 비디오 객체 생성 후 저장
+				Video video = new Video(summaryId);
 				video.markCompleted(response.videoUrl());
 				videoRepository.save(video);
 				log.info("✅ 비디오 생성 완료 - Video URL: {}", response.videoUrl());
@@ -58,7 +58,7 @@ public class VideoService {
 			}
 		}).exceptionally(ex -> {
 			log.error("❌ 예외 발생: {}", ex.getMessage(), ex);
-			return null;
+			throw new CompletionException(ex);
 		});
 	}
 


### PR DESCRIPTION
- exceptionally 블록에서 예외를 다시 던지도록 수정하여 CompletableFuture가 실패 상태로 완료되도록 함