### PR TITLE
Feat: 이미지 재생성 API 추가

### DIFF
--- a/src/main/java/elice/aishortform/image/controller/ImageApiDocs.java
+++ b/src/main/java/elice/aishortform/image/controller/ImageApiDocs.java
@@ -2,9 +2,12 @@ package elice.aishortform.image.controller;
 
 import elice.aishortform.image.dto.ImageGenerationRequestDto;
 import elice.aishortform.image.dto.ImageGenerationResponseDto;
+import elice.aishortform.image.dto.ImageGenerationResponseDto.ImageDto;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 public interface ImageApiDocs {
@@ -18,4 +21,13 @@ public interface ImageApiDocs {
     )
     @PostMapping("/generate-all")
     ResponseEntity<ImageGenerationResponseDto> generateImages(@RequestBody ImageGenerationRequestDto request);
+
+    @Operation(
+            summary = "기존 이미지 재생성",
+            description = "주어진 image_id에 대해 새로운 AI 이미지를 생성합니다. \n" +
+                    "- 요청: image_id \n" +
+                    "- 응답: image_id, image_url \n"
+    )
+    @PutMapping("/{image_id}/regenerate")
+    ResponseEntity<ImageDto> regenerateImage(@PathVariable("image_id") String imageId);
 }

--- a/src/main/java/elice/aishortform/image/controller/ImageGenerationController.java
+++ b/src/main/java/elice/aishortform/image/controller/ImageGenerationController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,5 +25,10 @@ public class ImageGenerationController implements ImageApiDocs {
     public ResponseEntity<ImageGenerationResponseDto> generateImages(@RequestBody ImageGenerationRequestDto request) {
         List<ImageDto> images = imageGenerationService.generateImages(request.summaryId(), request.style());
         return ResponseEntity.ok(new ImageGenerationResponseDto(images, images.size()));
+    }
+
+    public ResponseEntity<ImageDto> regenerateImage(@PathVariable("image_id") String imageId) {
+        ImageDto newImage = imageGenerationService.regenerateImage(imageId);
+        return ResponseEntity.ok(newImage);
     }
 }

--- a/src/main/java/elice/aishortform/image/entity/Image.java
+++ b/src/main/java/elice/aishortform/image/entity/Image.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "image")
-public class ImageEntity {
+public class Image {
 
     @Id
     @Column(name = "image_id", nullable = false, unique = true)

--- a/src/main/java/elice/aishortform/image/repository/ImageRepository.java
+++ b/src/main/java/elice/aishortform/image/repository/ImageRepository.java
@@ -1,9 +1,9 @@
 package elice.aishortform.image.repository;
 
-import elice.aishortform.image.entity.ImageEntity;
+import elice.aishortform.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ImageRepository extends JpaRepository<ImageEntity, String> {
+public interface ImageRepository extends JpaRepository<Image, String> {
 }

--- a/src/main/java/elice/aishortform/summary/service/SummarizeService.java
+++ b/src/main/java/elice/aishortform/summary/service/SummarizeService.java
@@ -161,4 +161,11 @@ public class SummarizeService {
     public void updateSummary(Summary summary) {
         summaryRepository.save(summary);
     }
+
+    public Summary getSummaryByImageId(String imageId) {
+        return summaryRepository.findAll().stream()
+                .filter(summary -> summary.getParagraphImageMap().containsValue(imageId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 image_id에 대한 Summary를 찾을 수 없습니다: " + imageId));
+    }
 }


### PR DESCRIPTION

## 📌 변경 사항
- 기존 이미지가 사용자의 기대에 부합하지 않을 경우 새 이미지 생성
- `PUT /images/{image_id}/regenerate` 엔드포인트 구현
- `imageId`를 기반으로 해당 이미지가 속한 `Summary` 조회 기능 추가
- 기존 문단 내용을 활용해 새로운 이미지 생성 및 저장
- `paragraphImageMap`을 업데이트하여 새로운 `imageId` 반영

## 🛠 수정된 파일
- `ImageGenerationService.java`
- `ImageGenerationController.java`
- `SummarizeService.java`
- `ImageApiDocs.java`


