### PR TITLE
Refactor: 이미지 재생성 시 새로운 ID 부여하도록 로직 개선

### DIFF
--- a/src/main/java/elice/aishortform/image/service/ImageGenerationService.java
+++ b/src/main/java/elice/aishortform/image/service/ImageGenerationService.java
@@ -105,15 +105,16 @@ public class ImageGenerationService {
 
         String paragraphText = summary.getParagraphs().get(paragraphIndex);
 
+        String newImageId = generateUniqueImageId();
         String base64Image = fetchImages(paragraphText, summary.getStyle());
-        String newImageUrl = saveImage(base64Image, imageId);
+        String newImageUrl = saveImage(base64Image, newImageId);
 
-        Image newImage = new Image(imageId, newImageUrl);
+        Image newImage = new Image(newImageId, newImageUrl);
         imageRepository.save(newImage);
-        summary.getParagraphImageMap().put(paragraphIndex, imageId);
+        summary.getParagraphImageMap().put(paragraphIndex, newImageId);
         summarizeService.updateSummary(summary);
 
-        return new ImageDto(imageId, newImageUrl);
+        return new ImageDto(newImageId, newImageUrl);
     }
 
     private String fetchImages(String prompt, String style) {


### PR DESCRIPTION

## 🔥 변경 사항
- `regenerateImage()`에서 기존 `imageId`를 재사용하지 않고 **새로운 UUID를 생성하여 저장**하도록 변경
- `paragraphImageMap`에서도 **기존 이미지 ID 대신 새로운 ID를 저장**하도록 수정
- 브라우저 캐시 문제를 해결하기 위해 **새로운 URL이 생성되도록 개선**