### PR TITLE
Feat: 테스트용 단일 이미지 생성 API 추가

### DIFF
--- a/src/main/java/elice/aishortform/image/controller/ImageApiDocs.java
+++ b/src/main/java/elice/aishortform/image/controller/ImageApiDocs.java
@@ -3,6 +3,7 @@ package elice.aishortform.image.controller;
 import elice.aishortform.image.dto.ImageGenerationRequestDto;
 import elice.aishortform.image.dto.ImageGenerationResponseDto;
 import elice.aishortform.image.dto.ImageGenerationResponseDto.ImageDto;
+import elice.aishortform.image.dto.TestImageGenerationRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,10 +25,19 @@ public interface ImageApiDocs {
 
     @Operation(
             summary = "기존 이미지 재생성",
-            description = "주어진 image_id에 대해 새로운 AI 이미지를 생성합니다. \n" +
-                    "- 요청: image_id \n" +
-                    "- 응답: image_id, image_url \n"
+            description = """
+                    주어진 image_id에 대해 새로운 AI 이미지를 생성합니다.\s
+                    - 요청: image_id\s
+                    - 응답: image_id, image_url\s
+                    """
     )
     @PutMapping("/{image_id}/regenerate")
     ResponseEntity<ImageDto> regenerateImage(@PathVariable("image_id") String imageId);
+
+    @Operation(
+            summary = "테스트용 단일 이미지 생성",
+            description = "임의의 프롬프트와 스타일을 입력하여 단일 이미지를 생성하는 테스트 API입니다."
+    )
+    @PostMapping("/generate-test-single")
+    ResponseEntity<ImageGenerationResponseDto.ImageDto> generateTestImages(@RequestBody TestImageGenerationRequestDto request);
 }

--- a/src/main/java/elice/aishortform/image/controller/ImageGenerationController.java
+++ b/src/main/java/elice/aishortform/image/controller/ImageGenerationController.java
@@ -3,6 +3,7 @@ package elice.aishortform.image.controller;
 import elice.aishortform.image.dto.ImageGenerationRequestDto;
 import elice.aishortform.image.dto.ImageGenerationResponseDto;
 import elice.aishortform.image.dto.ImageGenerationResponseDto.ImageDto;
+import elice.aishortform.image.dto.TestImageGenerationRequestDto;
 import elice.aishortform.image.service.ImageGenerationService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -30,5 +31,10 @@ public class ImageGenerationController implements ImageApiDocs {
     public ResponseEntity<ImageDto> regenerateImage(@PathVariable("image_id") String imageId) {
         ImageDto newImage = imageGenerationService.regenerateImage(imageId);
         return ResponseEntity.ok(newImage);
+    }
+
+    public ResponseEntity<ImageGenerationResponseDto.ImageDto> generateTestImages(@RequestBody TestImageGenerationRequestDto request) {
+        ImageDto image = imageGenerationService.generateTestImages(request.prompt(), request.style());
+        return ResponseEntity.ok(image);
     }
 }

--- a/src/main/java/elice/aishortform/image/dto/TestImageGenerationRequestDto.java
+++ b/src/main/java/elice/aishortform/image/dto/TestImageGenerationRequestDto.java
@@ -1,0 +1,4 @@
+package elice.aishortform.image.dto;
+
+public record TestImageGenerationRequestDto(String prompt, String style) {
+}

--- a/src/main/java/elice/aishortform/image/service/ImageGenerationService.java
+++ b/src/main/java/elice/aishortform/image/service/ImageGenerationService.java
@@ -117,6 +117,16 @@ public class ImageGenerationService {
         return new ImageDto(newImageId, newImageUrl);
     }
 
+    public ImageDto generateTestImages(String prompt, String style) {
+       String imageId = generateUniqueImageId();
+       String base64Image = fetchImages(prompt, style);
+
+        String imageUrl = saveImage(base64Image, imageId);
+        imageRepository.save(new Image(imageId,imageUrl));
+
+        return new ImageDto(imageId, imageUrl);
+    }
+
     private String fetchImages(String prompt, String style) {
         log.info("📌 이미지 생성 요청 ({}-style={})",prompt,style);
 


### PR DESCRIPTION
### 📌 작업 내용
- 프롬프트와 스타일을 입력하여 단일 이미지를 생성할 수 있는 테스트 API 추가
- `/images/generate-test-single` 엔드포인트에서 Swagger를 통해 테스트 가능
- `ImageGenerationService`에 테스트 전용 메서드 (`generateTestImages`) 추가
- `TestImageGenerationRequestDto`를 활용하여 요청 데이터 관리

### 📷 기능 예시
#### ✅ 요청 예시
```json
{
    "prompt": "하늘을 나는 나비",
    "style": "comic"
}
