### PR TITLE
Feat: 크롤링 오류 예외 처리 및 플랫폼별 요약 길이 제한 적용

### DIFF
--- a/src/main/java/elice/aishortform/summary/service/SummarizeService.java
+++ b/src/main/java/elice/aishortform/summary/service/SummarizeService.java
@@ -44,6 +44,10 @@ public class SummarizeService {
 
         // python 크롤링 요청
         String crawledContent = crawlingService.fetchCrawledContent(request.url());
+        if (crawledContent.startsWith("❌ 오류 발생:")) {
+            log.error("❌ 크롤링 실패: {}",crawledContent);
+            throw new IllegalArgumentException("크롤링 실패로 인해 요약을 진행할 수 없습니다. 오류 내용: " + crawledContent);
+        }
 
         String summaryText = fetchSummary(crawledContent).replace("\n"," ");
         List<String> paragraphs = Arrays.asList(summaryText.split("<br>"));


### PR DESCRIPTION

## 📌 변경 사항  
- 크롤링 오류 발생 시 예외 처리 추가  
  - `"❌ 오류 발생:"` 문자열로 시작하는 경우, `IllegalArgumentException`을 발생시켜 요약을 진행하지 않도록 수정  
  - 크롤링 오류가 발생하면 로그를 남기고 적절한 예외 메시지를 반환  

- 플랫폼별 요약 글자 수 제한 적용  
  - YouTube(2300자), TikTok(7800자), Instagram(1100자)로 요약 길이 제한을 설정  
  - AI 요청 시 시스템 메시지에 플랫폼별 글자 수 제한 정보를 포함하여 적절한 길이로 요약 생성 유도  
