### PR TITLE
Fix: springdoc-openapi 버전 호환성 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     // okhttp
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'


### PR DESCRIPTION
- springdoc-openapi 버전을 Spring Boot 3.2.x와 호환되는 최신 버전으로 업데이트